### PR TITLE
Update alpine

### DIFF
--- a/hadoop/current/Dockerfile
+++ b/hadoop/current/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.5
 MAINTAINER Jake Low <jake.low@isilon.com>
 
 USER root

--- a/hadoop/current/Makefile
+++ b/hadoop/current/Makefile
@@ -34,9 +34,10 @@ buildall:
 	$(MAKE) version=2.7.0 build
 	$(MAKE) version=2.7.1 build
 	$(MAKE) version=2.7.2 build
-	docker tag $(project):2.7.2 $(project):2.7
-	docker tag $(project):2.7.2 $(project):2
-	docker tag $(project):2.7.2 $(project):latest
+	$(MAKE) version=2.7.3 build
+	docker tag $(project):2.7.3 $(project):2.7
+	docker tag $(project):2.7.3 $(project):2
+	docker tag $(project):2.7.3 $(project):latest
 
 build:
 	docker build --build-arg version=$(version) -t $(project):$(version) .

--- a/hadoop/legacy/Dockerfile
+++ b/hadoop/legacy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.5
 MAINTAINER Jake Low <jake.low@isilon.com>
 
 USER root


### PR DESCRIPTION
Resolves #1 

```
$ make buildall
...
Successfully built aa8b08ee5fe4
make[1]: Leaving directory '/home/dtucker/projects/hadoop.docker/hadoop/current'
docker tag current:2.7.3 current:2.7
docker tag current:2.7.3 current:2
docker tag current:2.7.3 current:latest
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
current             2                   aa8b08ee5fe4        2 minutes ago       457 MB
current             2.7                 aa8b08ee5fe4        2 minutes ago       457 MB
current             2.7.3               aa8b08ee5fe4        2 minutes ago       457 MB
current             latest              aa8b08ee5fe4        2 minutes ago       457 MB
current             2.7.2               fdffb8ee9d60        4 minutes ago       455 MB
current             2.7.1               b1f23678d63c        6 minutes ago       454 MB
current             2.7.0               71c2f0fc172d        7 minutes ago       454 MB
current             2.6                 efb8a208b214        9 minutes ago       432 MB
current             2.6.3               efb8a208b214        9 minutes ago       432 MB
current             2.6.2               e28382125b86        11 minutes ago      432 MB
current             2.6.1               7b613b222cf8        14 minutes ago      432 MB
current             2.6.0               3360d525fd36        16 minutes ago      437 MB
current             2.5                 06b228a6dced        18 minutes ago      376 MB
current             2.5.2               06b228a6dced        18 minutes ago      376 MB
current             2.5.1               771267159a29        19 minutes ago      376 MB
current             2.5.0               700ed46ab94a        21 minutes ago      1.88 GB
current             2.4                 0d829e1ddbe8        25 minutes ago      359 MB
current             2.4.1               0d829e1ddbe8        25 minutes ago      359 MB
current             2.4.0               9bddf0db3973        26 minutes ago      361 MB
current             2.3                 2a09efe553b9        28 minutes ago      352 MB
current             2.3.0               2a09efe553b9        28 minutes ago      352 MB
current             2.2                 0baa983a734d        29 minutes ago      322 MB
current             2.2.0               0baa983a734d        29 minutes ago      322 MB
current             2.1-beta            779334f5a7c1        30 minutes ago      322 MB
current             2.1.1-beta          779334f5a7c1        30 minutes ago      322 MB
current             2.1.0-beta          b4e6260ab9b8        31 minutes ago      316 MB
current             2.0-alpha           34e05cc224df        33 minutes ago      237 MB
current             2.0.6-alpha         34e05cc224df        33 minutes ago      237 MB
current             2.0.5-alpha         0075c90bfedc        34 minutes ago      237 MB
current             2.0.4-alpha         9e9c3b6b20c4        36 minutes ago      297 MB
current             2.0.3-alpha         b417000342b4        37 minutes ago      298 MB
current             2.0.2-alpha         d06f16e71daa        38 minutes ago      296 MB
current             2.0.1-alpha         081c35efc8a6        39 minutes ago      283 MB
current             2.0.0-alpha         0ac65fc470d9        40 minutes ago      283 MB
alpine              3.5                 88e169ea8f46        5 weeks ago         3.98 MB
```
``` diff
$ cd ../../EXAMPLES/base-hadoop/
$ vim docker-compose.yaml 
$ git diff
diff --git a/EXAMPLES/base-hadoop/docker-compose.yaml b/EXAMPLES/base-hadoop/docker-compose.yaml
index 48c5043..aa3af2a 100644
--- a/EXAMPLES/base-hadoop/docker-compose.yaml
+++ b/EXAMPLES/base-hadoop/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   namenode:
-    image: "jakelow/hadoop:2"
+    image: "current:2"
     hostname: namenode
     volumes:
       - ./etc/hadoop:/etc/hadoop
@@ -9,7 +9,7 @@ services:
     command: hdfs namenode
 
   datanode:
-    image: "jakelow/hadoop:2"
+    image: "current:2"
     links:
       - namenode
     volumes:
@@ -18,7 +18,7 @@ services:
     command: hdfs datanode
 
   resourcemanager:
-    image: "jakelow/hadoop:2"
+    image: "current:2"
     hostname: resourcemanager
     links:
       - namenode
@@ -28,7 +28,7 @@ services:
     command: yarn resourcemanager
 
   nodemanager:
-    image: "jakelow/hadoop:2"
+    image: "current:2"
     links:
       - resourcemanager
       - namenode
```
```
$ docker-compose up --build -d
Creating network "basehadoop_default" with the default driver
Creating basehadoop_namenode_1
Creating basehadoop_resourcemanager_1
Creating basehadoop_datanode_1
Creating basehadoop_nodemanager_1
$ docker-compose ps
            Name                     Command          State   Ports 
-------------------------------------------------------------------
basehadoop_datanode_1          hdfs datanode          Up            
basehadoop_namenode_1          hdfs namenode          Up            
basehadoop_nodemanager_1       yarn nodemanager       Up            
basehadoop_resourcemanager_1   yarn resourcemanager   Up            
$ sleep 60
$ docker-compose ps
            Name                     Command          State   Ports 
-------------------------------------------------------------------
basehadoop_datanode_1          hdfs datanode          Up            
basehadoop_namenode_1          hdfs namenode          Up            
basehadoop_nodemanager_1       yarn nodemanager       Up            
basehadoop_resourcemanager_1   yarn resourcemanager   Up
```